### PR TITLE
separated messages, and responses in server

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,20 @@ If you'd like to hot-reload your server on code changes, add the `--debug` flag 
 The currently supported commands are -
 
 ```markdown
-* `show deals`: to display available BOGO deals
-* `status`: to show your subscription status
-* `subscribe`: to start getting matched with other BOGOBot users for pair lunching
-* `unsubscribe`: to stop getting matched
+- `show deals`: to display available BOGO deals
+- `status`: to show your subscription status
+- `subscribe`: to start getting matched with other BOGOBot users for pair lunching
+- `unsubscribe`: to stop getting matched
 ```
 
 ## TO DO
 
 - user functionality
-  - [ ] user scheduling preferences
+
+  - [x] user scheduling preferences
 
 - pairing functionality
+
   - [ ] update command list for when users are in the process of getting paired?
   - [ ] determine what pref info to get from users
     - deals are going up and down very frequently, should we present food/deal pref option with the risk it goes down, or do we keep it so people getting paired have an idea of what the other person wants to eat?
@@ -88,6 +90,7 @@ The currently supported commands are -
   - [ ] followup for weekly stats
 
 - unit testing
+
   - [x] check zulip rc client connection
   - [x] check supabase connection
   - [ ] load in testing db

--- a/architecture.md
+++ b/architecture.md
@@ -9,6 +9,7 @@
 
 - `show deals`
 - `status`
+- `schedule`
 - `subscribe`
 - `unsubscribe`
 

--- a/message.py
+++ b/message.py
@@ -8,6 +8,15 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
+
+PAIRING_COMMANDS = """
+Hey! This is BOGO bot! If you want to get paired for BOGO deals today, please respond!
+- `sign me up boss`: yes :money_face:
+- `shaddup`: skip today :pleading_face:
+- `show deals first`: see current deals before deciding, but these change *frequently* throughout the day!
+"""
+
+
 try:
     supabase_client: Client = utils.init_supabase_client()
     client = zulip.Client(
@@ -20,34 +29,39 @@ except (EnvironmentError, zulip.ConfigNotFoundError) as e:
     pprint(e)
     sys.exit(1)
 
+###     PRODUCTION MESSAGES     ###
 
-def message_all_subscribers_individually():
-    # user_ids = [677939, 690946, 677960]
-    subscribed_users = utils.get_subscribed_users(supabase_client)
 
-    for user in subscribed_users.data:
+###     TEST MESSAGES       ###
+
+
+def daily_message_blast():
+    daily_user_ids = utils.get_todays_users(supabase_client)
+    print(f"actual daily user_ids in daily message blast {daily_user_ids}")
+    # daily_user_ids = [677939, 674511]   #mani & stef
+    daily_user_ids = [674511]  # stef
+
+    message_individuals(daily_user_ids, PAIRING_COMMANDS)
+
+
+def message_individuals(user_ids, contents):
+    for user in user_ids:
         result = client.send_message(
             message_data={
                 "type": "private",
-                "to": [user["zulip_user_id"]],
-                "content": utils.get_show_deals_message(),
+                "to": [user],
+                "content": contents,
             }
         )
-        pprint(result)
+        # pprint(result)
 
 
-def message_group():
-    todays_users = utils.get_todays_users(supabase_client)
-    user_ids = [user["zulip_user_id"] for user in todays_users]
-
-    # FOR DEV PURPOSES SO WE DONT SPAM EVERYONE
-    user_ids = [677939, 674511]
-
+def message_group(user_ids, contents):
     result = client.send_message(
         message_data={
             "type": "private",
             "to": user_ids,
-            "content": "Hello this is a pairing message test!",
+            "content": contents,
         }
     )
-    pprint(result)
+    # pprint(result)

--- a/message.py
+++ b/message.py
@@ -21,7 +21,7 @@ except (EnvironmentError, zulip.ConfigNotFoundError) as e:
     sys.exit(1)
 
 
-def message_all_subscribers_ind():
+def message_all_subscribers_individually():
     # user_ids = [677939, 690946, 677960]
     subscribed_users = utils.get_subscribed_users(supabase_client)
 
@@ -38,15 +38,16 @@ def message_all_subscribers_ind():
 
 def message_group():
     todays_users = utils.get_todays_users(supabase_client)
-    user_ids = []
-    for user in todays_users.data:
-        user_ids.append(user["zulip_user_id"])
+    user_ids = [user["zulip_user_id"] for user in todays_users]
+
+    # FOR DEV PURPOSES SO WE DONT SPAM EVERYONE
+    user_ids = [677939, 674511]
 
     result = client.send_message(
         message_data={
             "type": "private",
-            "to": [user_ids],
-            "content": "Hello this is a group message test!",
+            "to": user_ids,
+            "content": "Hello this is a pairing message test!",
         }
     )
     pprint(result)

--- a/server.py
+++ b/server.py
@@ -21,6 +21,12 @@ Commands:
 * `unsubscribe`: to stop getting matched
 """
 
+SHOW_DEALS_FIRST = utils.get_show_deals_message() + """
+    
+*Would you like to be paired?*
+* `sign me up boss` or `shaddup`
+""" #dont remove the blank line in this...
+
 try:
     supabase_client: Client = utils.init_supabase_client()
 except EnvironmentError as e:
@@ -49,6 +55,21 @@ def handle():
         if content == "about":
             return {"content": "Hello! This is BOGO bot! Please type 'help' for help!"}
 
+    ##       DEV RESPONSES          ##
+        elif content == "today":
+            zulip_message.daily_message_blast()
+            return {"content": 'testing...'} 
+        
+        elif content == "sign me up boss":
+            pass
+
+        elif content == "shaddup":
+            return {"content": "Skipping pairing today"}
+
+        elif content == "show deals first":
+            return {"content": SHOW_DEALS_FIRST}
+        
+
         elif content == "all subs":
             all_data = utils.get_subscribed_users(supabase_client)
             all_users = []
@@ -58,11 +79,10 @@ def handle():
 
             return {"content": '\n'.join(all_users) if all_users else 'No subscribed users yet!'}
 
-        elif content == "today":
-            daily = utils.get_todays_users(supabase_client)
-            zulip_message.message_group()
-            return {"content": daily.data} 
 
+
+
+        ##       PRODUCTION RESPONSES        ##
 
         elif content == "status":
             user_data = utils.get_user(supabase_client, sender_id)

--- a/server.py
+++ b/server.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import utils
-import message
+import message as zulip_message
 
 from flask import Flask, request
 from pprint import pprint
@@ -60,8 +60,8 @@ def handle():
 
         elif content == "today":
             daily = utils.get_todays_users(supabase_client)
-            # message.message_group()
-            return {"content": daily.data}
+            zulip_message.message_group()
+            return {"content": daily.data} 
 
 
         elif content == "status":

--- a/utils.py
+++ b/utils.py
@@ -58,7 +58,7 @@ def get_todays_users(supabase_client):
         .or_(f'schedule.is.null, schedule.cs.{{"{weekday[today]}"}}')
         .execute()
     )
-    return daily_users
+    return [user["zulip_user_id"] for user in daily_users.data]
 
 
 #
@@ -71,14 +71,14 @@ def update_user_schedule(supabase_client, user_id, schedule):
     parsed_schedule = [
         day.lower() for day in schedule.strip().split() if day.lower() in valid_days
     ]
+    parsed_schedule = None if not parsed_schedule else parsed_schedule
     user_data = (
         supabase_client.table("users")
-        # .update({"schedule": " ".join(parsed_schedule)})
-        .update({"schedule": parsed_schedule})
+        .update({"schedule": parsed_schedule, "is_subscribed": True})
         .eq("zulip_user_id", user_id)
         .execute()
     )
-    return " ".join(parsed_schedule)
+    return "all days of the week" if not parsed_schedule else " ".join(parsed_schedule)
 
 
 def get_subscribed_users(supabase_client):


### PR DESCRIPTION
messages broken up into prod/dev, and individual/group messages - both inheriting [user_ids] and contents to send out
-should make it easier down the road to have pairing messages sent to couples, daily blast sent out, messages about remaining queue, etc

some updated responses for the daily pairing portion